### PR TITLE
Add invertStrings option to flip string order (#9)

### DIFF
--- a/src/constants/tabRendererConstants.ts
+++ b/src/constants/tabRendererConstants.ts
@@ -8,6 +8,7 @@ export const TabsRendererConstants = {
   STRING_SPACING: 16,
   MIN_STRING_SPACING: 9,
   MAX_STRING_SPACING: 24,
+  INVERT_STRINGS: false,
   MEASURE_GAP: 0,
   ROW_GAP: 34,
   TAB_PADDING_X: 18,

--- a/src/types/UI/rendererOptions.ts
+++ b/src/types/UI/rendererOptions.ts
@@ -10,6 +10,7 @@ export type TabRendererOptions = {
   minStringSpacing?: number;
   stringSpacing?: number;
   maxStringSpacing?: number;
+  invertStrings?: boolean;
   measureGap?: number;
   rowGap?: number;
   paddingX?: number;

--- a/src/utils/tabs/notesRenderer.ts
+++ b/src/utils/tabs/notesRenderer.ts
@@ -18,6 +18,7 @@ type NotesRenderRequest = {
   beatLayouts: BeatLayout[];
   bounds: MeasureBounds;
   stringCount: number;
+  invertStrings?: boolean;
   config: NoteConfig;
 };
 
@@ -30,6 +31,7 @@ type NoteRenderRequest = {
   note: Note;
   bounds: MeasureBounds;
   stringCount: number;
+  invertStrings: boolean;
   config: NoteConfig;
 };
 
@@ -41,6 +43,7 @@ export function renderMeasureNotes(request: NotesRenderRequest) {
     beatLayouts,
     bounds,
     stringCount,
+    invertStrings = false,
     config,
   } = request;
 
@@ -60,6 +63,7 @@ export function renderMeasureNotes(request: NotesRenderRequest) {
         note,
         bounds,
         stringCount,
+        invertStrings,
         config,
       });
     }
@@ -76,6 +80,7 @@ function renderNote(request: NoteRenderRequest) {
     note,
     bounds,
     stringCount,
+    invertStrings,
     config,
   } = request;
 
@@ -86,10 +91,9 @@ function renderNote(request: NoteRenderRequest) {
     return;
   }
 
+  const stringRow = invertStrings ? stringCount - note.string : note.string - 1;
   const y =
-    bounds.y +
-    constants.MEASURE_TOP_PADDING +
-    (note.string - 1) * bounds.stringSpacing;
+    bounds.y + constants.MEASURE_TOP_PADDING + stringRow * bounds.stringSpacing;
 
   const context: NoteRenderContext = {
     note,

--- a/src/utils/tabs/tabsOptionsNormalizer.ts
+++ b/src/utils/tabs/tabsOptionsNormalizer.ts
@@ -22,6 +22,8 @@ export function normalizeOptions(options: TabRendererOptions) {
 
     maxStringSpacing: options.maxStringSpacing ?? constants.MAX_STRING_SPACING,
 
+    invertStrings: options.invertStrings ?? constants.INVERT_STRINGS,
+
     measureGap: options.measureGap ?? constants.MEASURE_GAP,
 
     rowGap: options.rowGap ?? constants.ROW_GAP,

--- a/src/utils/tabs/tabsRenderer.ts
+++ b/src/utils/tabs/tabsRenderer.ts
@@ -209,6 +209,7 @@ export class TabsRenderer {
       beatLayouts,
       bounds,
       stringCount: layout.stringCount,
+      invertStrings: config.invertStrings,
       config: config.notes,
     });
   }

--- a/tests/notesRenderer.test.ts
+++ b/tests/notesRenderer.test.ts
@@ -243,6 +243,31 @@ describe("renderMeasureNotes", () => {
     expect(Number(bg.getAttribute("y"))).toBeLessThan(expectedY);
   });
 
+  it("mirrors the string row vertically when invertStrings is set", () => {
+    const measure = makeMeasureFromVoices([
+      [makeBeat({ notes: [makeNote({ string: 1 })] })],
+    ]);
+    const parent = makeParent();
+    const bounds = makeBounds({ y: 40, stringSpacing: 12 });
+
+    renderMeasureNotes({
+      parent,
+      measure,
+      measureIndex: 0,
+      beatLayouts: [makeBeatLayout()],
+      bounds,
+      stringCount: 6,
+      invertStrings: true,
+      config: makeNoteConfig(),
+    });
+
+    // string 1 of 6 sits on the bottom row (index 5) when inverted.
+    const expectedY =
+      bounds.y + constants.MEASURE_TOP_PADDING + 5 * bounds.stringSpacing;
+    const note = parent.querySelector("g.tab-note")!;
+    expect(note.getAttribute("y")).toBe(`${expectedY}`);
+  });
+
   it("omits the background rect when background is false", () => {
     const measure = makeMeasureFromVoices([
       [makeBeat({ notes: [makeNote()] })],

--- a/tests/tabsOptionsNormalizer.test.ts
+++ b/tests/tabsOptionsNormalizer.test.ts
@@ -40,6 +40,14 @@ describe("normalizeOptions", () => {
     expect(normalizeOptions({ measuresPerRow: -5 }).measuresPerRow).toBe(1);
   });
 
+  it("defaults invertStrings to the constant and respects an explicit value", () => {
+    expect(normalizeOptions({}).invertStrings).toBe(constants.INVERT_STRINGS);
+    expect(normalizeOptions({ invertStrings: true }).invertStrings).toBe(true);
+    expect(normalizeOptions({ invertStrings: false }).invertStrings).toBe(
+      false,
+    );
+  });
+
   describe("notes", () => {
     it("falls back to constants when notes are omitted", () => {
       const { notes } = normalizeOptions({});


### PR DESCRIPTION
Adds a renderer-level `invertStrings` option (default false) that mirrors each note vertically, so string 1 is drawn on the bottom line instead of the top. Threaded from normalizeOptions through the notes renderer, which maps a note to `stringCount - note.string` when inverted.

Covers the new option in the normalizer and note-placement tests.