### PR TITLE
Ship default tab-note transform styles (#31)

### DIFF
--- a/src/constants/tabRendererConstants.ts
+++ b/src/constants/tabRendererConstants.ts
@@ -28,4 +28,6 @@ export const TabsRendererConstants = {
   NOTE_PADDING_X: 3,
   NOTE_BACKGROUND_HEIGHT: 12,
   NOTE_CLASS_PREFIX: "tab-note",
+  NOTE_TRANSFORM_BOX: "fill-box",
+  NOTE_TRANSFORM_ORIGIN: "center",
 };

--- a/src/types/UI/tabNoteOptions.ts
+++ b/src/types/UI/tabNoteOptions.ts
@@ -11,4 +11,5 @@ export type TabNoteOptions = {
   backgroundHeight?: number;
   background?: boolean;
   classPrefix?: string;
+  defaultStyles?: boolean;
 };

--- a/src/utils/tabs/notesStyles.ts
+++ b/src/utils/tabs/notesStyles.ts
@@ -1,0 +1,13 @@
+import { TabsRendererConstants as constants } from "../../constants/tabRendererConstants";
+
+// Default, package-shipped styles for tab notes. These set the transform box
+// and origin so any consumer CSS transform (scale, rotate, …) applied to a note
+// pivots around the note's own centre rather than the SVG origin. Appearance
+// still lives in the consumer's stylesheet — only transform geometry is set here.
+export function buildNoteStyles(classPrefix: string): string {
+  return (
+    `.${classPrefix} { ` +
+    `transform-box: ${constants.NOTE_TRANSFORM_BOX}; ` +
+    `transform-origin: ${constants.NOTE_TRANSFORM_ORIGIN}; }`
+  );
+}

--- a/src/utils/tabs/tabsOptionsNormalizer.ts
+++ b/src/utils/tabs/tabsOptionsNormalizer.ts
@@ -42,6 +42,7 @@ function normalizeNoteOptions(options: TabNoteOptions) {
       options.backgroundHeight ?? constants.NOTE_BACKGROUND_HEIGHT,
     background: options.background ?? true,
     classPrefix: options.classPrefix ?? constants.NOTE_CLASS_PREFIX,
+    defaultStyles: options.defaultStyles ?? true,
     render: options.render,
     onCreate: options.onCreate,
     onClick: options.onClick,

--- a/src/utils/tabs/tabsRenderer.ts
+++ b/src/utils/tabs/tabsRenderer.ts
@@ -11,6 +11,7 @@ import { normalizeOptions } from "./tabsOptionsNormalizer";
 import { LayoutCalculation } from "./layoutCalculation";
 import { calculateBeatLayouts } from "./notesLayout";
 import { renderMeasureNotes } from "./notesRenderer";
+import { buildNoteStyles } from "./notesStyles";
 
 type RepeatLine = {
   className: string;
@@ -67,6 +68,7 @@ export class TabsRenderer {
       const layout = layoutCalculation.calculateLayout(svgWidth, measures);
 
       this.clearSvg(svg);
+      this.renderDefaultStyles(svg, config);
 
       const pass: RenderPass = {
         layout,
@@ -427,6 +429,16 @@ export class TabsRenderer {
     repeatCountText.textContent = `x${repeatCount}`;
 
     parent.append(repeatCountText);
+  }
+
+  private renderDefaultStyles(svg: SVGSVGElement, config: RendererConfig) {
+    if (!config.notes.defaultStyles) {
+      return;
+    }
+
+    const style = this.createSvgElement("style");
+    style.textContent = buildNoteStyles(config.notes.classPrefix);
+    svg.append(style);
   }
 
   private clearSvg(svg: SVGSVGElement) {

--- a/tests/notesStyles.test.ts
+++ b/tests/notesStyles.test.ts
@@ -1,0 +1,23 @@
+import { TabsRendererConstants as constants } from "../src/constants/tabRendererConstants";
+import { buildNoteStyles } from "../src/utils/tabs/notesStyles";
+
+describe("buildNoteStyles", () => {
+  it("scopes the rule to the given class prefix", () => {
+    expect(buildNoteStyles("tab-note")).toMatch(/^\.tab-note\s*\{/);
+    expect(buildNoteStyles("note")).toMatch(/^\.note\s*\{/);
+  });
+
+  it("sets transform-box and transform-origin from the constants", () => {
+    const css = buildNoteStyles(constants.NOTE_CLASS_PREFIX);
+
+    expect(css).toContain(`transform-box: ${constants.NOTE_TRANSFORM_BOX};`);
+    expect(css).toContain(
+      `transform-origin: ${constants.NOTE_TRANSFORM_ORIGIN};`,
+    );
+  });
+
+  it("uses fill-box and center as the shipped defaults", () => {
+    expect(constants.NOTE_TRANSFORM_BOX).toBe("fill-box");
+    expect(constants.NOTE_TRANSFORM_ORIGIN).toBe("center");
+  });
+});

--- a/tests/tabsOptionsNormalizer.test.ts
+++ b/tests/tabsOptionsNormalizer.test.ts
@@ -64,6 +64,14 @@ describe("normalizeOptions", () => {
       expect(notes.background).toBe(false);
     });
 
+    it("defaults defaultStyles to true and respects an explicit false", () => {
+      expect(normalizeOptions({}).notes.defaultStyles).toBe(true);
+      expect(
+        normalizeOptions({ notes: { defaultStyles: false } }).notes
+          .defaultStyles,
+      ).toBe(false);
+    });
+
     it("overrides size, padding and prefix when provided", () => {
       const { notes } = normalizeOptions({
         notes: { fontSize: 14, paddingX: 6, classPrefix: "note" },

--- a/tests/tabsRendererStyles.test.ts
+++ b/tests/tabsRendererStyles.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TabsRenderer } from "../src/utils/tabs/tabsRenderer";
+import {
+  makeBeat,
+  makeMeasureFromVoices,
+  makeNote,
+  makeSong,
+} from "./fixtures";
+import type { Track } from "../src/types/track";
+
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+function makeTrackWithNotes(): Track {
+  const measure = makeMeasureFromVoices([
+    [makeBeat({ notes: [makeNote({ string: 1, value: 3 })] })],
+  ]);
+  return {
+    name: "Track",
+    strings: Array.from({ length: 6 }, (_, index) => [index, 0]),
+    measures: [measure],
+  } as unknown as Track;
+}
+
+function setupSvg(): SVGSVGElement {
+  document.body.innerHTML = '<div><svg id="tabs"></svg></div>';
+  return document.querySelector("#tabs") as SVGSVGElement;
+}
+
+describe("TabsRenderer default styles", () => {
+  beforeAll(() => {
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver =
+      ResizeObserverStub;
+  });
+
+  it("injects a <style> with the tab-note transform defaults", () => {
+    const svg = setupSvg();
+    const renderer = new TabsRenderer(makeSong([makeTrackWithNotes()]));
+
+    renderer.generateMeasures();
+
+    const style = svg.querySelector("style");
+    expect(style).not.toBeNull();
+    expect(style!.textContent).toContain("transform-box: fill-box;");
+    expect(style!.textContent).toContain("transform-origin: center;");
+  });
+
+  it("omits the <style> when notes.defaultStyles is false", () => {
+    const svg = setupSvg();
+    const renderer = new TabsRenderer(makeSong([makeTrackWithNotes()]));
+
+    renderer.generateMeasures(0, { notes: { defaultStyles: false } });
+
+    expect(svg.querySelector("style")).toBeNull();
+  });
+});


### PR DESCRIPTION
The renderer now injects a scoped <style> into the target SVG that sets `transform-box: fill-box` and `transform-origin: center` on the tab-note class, so any consumer CSS transform on a note pivots around the note's own centre. Styles are built from constants by buildNoteStyles and can be opted out via the `notes.defaultStyles` option (default true).

Covers the style builder, the new option, and the injection behaviour.